### PR TITLE
feat: add AdSense in-feed ad to projects feeds

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -8,6 +8,10 @@ declare global {
 		// interface PageState {}
 		// interface Platform {}
 	}
+
+	interface Window {
+		adsbygoogle: Array<Record<string, unknown>>;
+	}
 }
 
 export {};

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,11 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<script
+			async
+			src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-7131271092857002"
+			crossorigin="anonymous"
+		></script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/entities/ad/config.ts
+++ b/src/lib/entities/ad/config.ts
@@ -1,0 +1,19 @@
+// Google AdSense configuration.
+//
+// The publisher (client) ID is fixed for your account. To turn the in-feed
+// ad on, create an "In-feed" ad unit in the AdSense dashboard
+// (Ads → By ad unit → In-feed ads) and paste the two generated values below.
+//
+//  - ADSENSE_INFEED_SLOT       -> the `data-ad-slot` value (a number string)
+//  - ADSENSE_INFEED_LAYOUT_KEY -> the `data-ad-layout-key` value (e.g. -fb+5w+4e-db+86)
+//
+// Until both are filled in, <AdCard /> renders a styled "Sponsored" placeholder
+// instead of a live ad, so the layout stays previewable in dev.
+
+export const ADSENSE_CLIENT = 'ca-pub-7131271092857002';
+
+export const ADSENSE_INFEED_SLOT = '6385011722';
+export const ADSENSE_INFEED_LAYOUT_KEY = '-73+ed+2i-1n-4w';
+
+export const adsenseConfigured =
+	ADSENSE_INFEED_SLOT.length > 0 && ADSENSE_INFEED_LAYOUT_KEY.length > 0;

--- a/src/lib/entities/ad/index.ts
+++ b/src/lib/entities/ad/index.ts
@@ -1,0 +1,7 @@
+export { AdCard } from './ui';
+export {
+	ADSENSE_CLIENT,
+	ADSENSE_INFEED_SLOT,
+	ADSENSE_INFEED_LAYOUT_KEY,
+	adsenseConfigured
+} from './config';

--- a/src/lib/entities/ad/ui/AdCard.svelte
+++ b/src/lib/entities/ad/ui/AdCard.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
+	import { css, cx } from 'styled-system/css';
+	import {
+		ADSENSE_CLIENT,
+		ADSENSE_INFEED_SLOT,
+		ADSENSE_INFEED_LAYOUT_KEY,
+		adsenseConfigured
+	} from '$lib/entities/ad/config';
+
+	// The <ins> AdSense renders into. Bound so we can guard against pushing twice.
+	let insEl = $state<HTMLModElement>();
+
+	onMount(() => {
+		if (!browser || !adsenseConfigured || !insEl) return;
+		// On client-side re-navigation the same element can persist; AdSense
+		// throws if a slot already has a status. Push only once.
+		if (insEl.getAttribute('data-adsbygoogle-status')) return;
+		try {
+			(window.adsbygoogle = window.adsbygoogle || []).push({});
+		} catch (error) {
+			console.error('adsbygoogle push failed', error);
+		}
+	});
+
+	// Wrapper matches ProjectCard so the ad sits flush in the feed.
+	const wrapper = css({
+		display: 'block',
+		bg: 'surface.muted',
+		borderRadius: 'xl',
+		overflow: 'hidden',
+		h: '100%'
+	});
+</script>
+
+{#if adsenseConfigured}
+	<div class={wrapper}>
+		<ins
+			bind:this={insEl}
+			class={cx('adsbygoogle', css({ display: 'block' }))}
+			data-ad-format="fluid"
+			data-ad-layout-key={ADSENSE_INFEED_LAYOUT_KEY}
+			data-ad-client={ADSENSE_CLIENT}
+			data-ad-slot={ADSENSE_INFEED_SLOT}
+		></ins>
+	</div>
+{:else}
+	<!-- Preview placeholder shown until the in-feed ad unit IDs are set in config.ts -->
+	<div class={wrapper} aria-label="Advertisement">
+		<div
+			class={css({
+				position: 'relative',
+				w: '100%',
+				h: '48',
+				bgGradient: 'to-br',
+				gradientFrom: 'surface.subtle',
+				gradientTo: 'border',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center'
+			})}
+		>
+			<span
+				class={css({
+					position: 'absolute',
+					top: '3',
+					right: '3',
+					fontSize: '2xs',
+					fontWeight: 'semibold',
+					letterSpacing: 'wider',
+					textTransform: 'uppercase',
+					color: 'text.subtle',
+					bg: 'surface',
+					px: '2',
+					py: '0.5',
+					borderRadius: 'md',
+					opacity: 0.85
+				})}
+			>
+				Sponsored
+			</span>
+			<span class={css({ fontSize: 'sm', color: 'text.subtle' })}>Ad preview</span>
+		</div>
+		<div class={css({ p: '5' })}>
+			<h3 class={css({ fontSize: 'lg', fontWeight: 'bold', mb: '2', color: 'text' })}>
+				Your ad could be here
+			</h3>
+			<p class={css({ color: 'text.muted', lineHeight: 'relaxed', fontSize: 'sm' })}>
+				This card becomes a live in-feed ad once the AdSense slot is configured.
+			</p>
+		</div>
+	</div>
+{/if}

--- a/src/lib/entities/ad/ui/index.ts
+++ b/src/lib/entities/ad/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as AdCard } from './AdCard.svelte';

--- a/src/lib/entities/project/ui/ProjectGrid.svelte
+++ b/src/lib/entities/project/ui/ProjectGrid.svelte
@@ -2,27 +2,42 @@
 	import { css } from 'styled-system/css';
 	import type { Project } from '$lib/entities/project';
 	import ProjectCard from './ProjectCard.svelte';
+	import { AdCard } from '$lib/entities/ad';
 	import { onMount } from 'svelte';
 	import { Spring } from 'svelte/motion';
 
 	interface Props {
 		projects: Project[];
+		/** 0-based grid position to insert an in-feed ad card. Omit to show no ad. */
+		adIndex?: number;
 	}
 
-	let { projects }: Props = $props();
+	let { projects, adIndex }: Props = $props();
+
+	type GridItem = { type: 'project'; project: Project } | { type: 'ad' };
+
+	// Build the rendered item list once, inserting the ad at the requested slot.
+	const items: GridItem[] = (() => {
+		const list: GridItem[] = projects.map((project) => ({ type: 'project', project }));
+		if (typeof adIndex === 'number') {
+			const pos = Math.max(0, Math.min(adIndex, list.length));
+			list.splice(pos, 0, { type: 'ad' });
+		}
+		return list;
+	})();
 
 	interface CardState {
 		opacity: Spring<number>;
 		y: Spring<number>;
 	}
 
-	let cardStates: CardState[] = projects.map(() => ({
+	let cardStates: CardState[] = items.map(() => ({
 		opacity: new Spring(0, { stiffness: 0.05, damping: 0.6 }),
 		y: new Spring(30, { stiffness: 0.05, damping: 0.6 })
 	}));
 
 	onMount(() => {
-		projects.forEach((_, i) => {
+		items.forEach((_, i) => {
 			setTimeout(() => {
 				cardStates[i].opacity.set(1);
 				cardStates[i].y.set(0);
@@ -38,12 +53,16 @@
 		gap: '4'
 	})}
 >
-	{#each projects as project, i}
+	{#each items as item, i}
 		<div
 			style="opacity: {cardStates[i].opacity.current}; transform: translateY({cardStates[i].y
 				.current}px);"
 		>
-			<ProjectCard {project} />
+			{#if item.type === 'project'}
+				<ProjectCard project={item.project} />
+			{:else}
+				<AdCard />
+			{/if}
 		</div>
 	{/each}
 </div>

--- a/src/lib/widgets/Projects.svelte
+++ b/src/lib/widgets/Projects.svelte
@@ -5,5 +5,5 @@
 </script>
 
 <Section title="Projects" id="projects">
-	<ProjectGrid {projects} />
+	<ProjectGrid {projects} adIndex={projects.length} />
 </Section>

--- a/src/routes/projects/[slug]/+page.svelte
+++ b/src/routes/projects/[slug]/+page.svelte
@@ -167,7 +167,7 @@
 				Other Projects
 			</h2>
 
-			<ProjectGrid projects={otherProjects} />
+			<ProjectGrid projects={otherProjects} adIndex={otherProjects.length} />
 		</div>
 	{/if}
 </div>

--- a/static/ads.txt
+++ b/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7131271092857002, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## What

Adds a Google AdSense **in-feed native ad** styled to look just like the project/article cards, plus the required `ads.txt`.

## Changes

- **`static/ads.txt`** — publisher record (`pub-7131271092857002`).
- **`src/app.html`** — AdSense loader script in `<head>` (loaded once site-wide).
- **`src/lib/entities/ad/`** — new ad entity:
  - `config.ts` — client / slot (`6385011722`) / layout key (`-73+ed+2i-1n-4w`).
  - `AdCard.svelte` — renders the in-feed `fluid` `<ins>` unit, pushes `adsbygoogle` on mount (browser-guarded + double-push guard). Falls back to a styled "Sponsored" placeholder when the slot is unconfigured.
- **`ProjectGrid.svelte`** — optional `adIndex` prop to slot the ad into the grid, preserving the fade-in animation.
- Ad appended to the home **Projects** feed and the **Other Projects** grid on detail pages.

## Notes

- The ad blends visually (the point of in-feed native ads); Google still renders its own "Ad/Sponsored" attribution inside the unit, which is policy-required.
- `yarn check` and `yarn build` pass; live `<ins>` markup confirmed in prerendered output.
- New ad units commonly serve blank for a few hours to ~a day; blank ≠ broken. Ads never render on localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)